### PR TITLE
Fairysf wrapper placeholder classes to integrate shogi and xiangqi

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chessops",
-  "version": "0.8.1-pstrat2",
+  "version": "0.8.1-pstrat3.1",
   "description": "Chess and chess variant rules and operations",
   "keywords": [
     "chess",

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -62,6 +62,8 @@ export function lichessVariantRules(
     | 'racingKings'
     | 'crazyhouse'
     | 'linesOfAction'
+    | 'shogi'
+    | 'xiangqi'
 ): Rules {
   switch (variant) {
     case 'standard':

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,6 +116,8 @@ export const RULES = [
   'racingkings',
   'crazyhouse',
   'linesofaction',
+  'shogi',
+  'xiangqi',
 ] as const;
 
 export type Rules = typeof RULES[number];

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -576,6 +576,9 @@ export function defaultPosition(rules: Rules): Position {
       return Crazyhouse.default();
     case 'linesofaction':
       return LinesOfAction.default();
+    default:
+      //TODO fix this for xiangqi, shogi and fairy games
+      return Chess.default();
   }
 }
 
@@ -599,5 +602,8 @@ export function setupPosition(rules: Rules, setup: Setup): Result<Position, Posi
       return Crazyhouse.fromSetup(setup);
     case 'linesofaction':
       return LinesOfAction.fromSetup(setup);
+    default:
+      //TODO fix this for xiangqi, shogi and fairy games
+      return Chess.fromSetup(setup);
   }
 }

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -556,6 +556,52 @@ export class LinesOfAction extends Chess {
   }
 }
 
+export class Shogi extends Chess {
+  //TODO - move into own class and have variant family
+  protected constructor() {
+    super('shogi');
+  }
+
+  static default(): Shogi {
+    return super.default();
+  }
+
+  static fromSetup(setup: Setup): Result<Shogi, PositionError> {
+    return super.fromSetup(setup);
+  }
+
+  clone(): Shogi {
+    return super.clone() as Shogi;
+  }
+
+  hasInsufficientMaterial(_color: Color): boolean {
+    return false;
+  }
+}
+
+export class Xiangqi extends Chess {
+  //TODO - move into own class and have variant family
+  protected constructor() {
+    super('xiangqi');
+  }
+
+  static default(): Xiangqi {
+    return super.default();
+  }
+
+  static fromSetup(setup: Setup): Result<Xiangqi, PositionError> {
+    return super.fromSetup(setup);
+  }
+
+  clone(): Xiangqi {
+    return super.clone() as Xiangqi;
+  }
+
+  hasInsufficientMaterial(_color: Color): boolean {
+    return false;
+  }
+}
+
 export function defaultPosition(rules: Rules): Position {
   switch (rules) {
     case 'chess':
@@ -576,9 +622,10 @@ export function defaultPosition(rules: Rules): Position {
       return Crazyhouse.default();
     case 'linesofaction':
       return LinesOfAction.default();
-    default:
-      //TODO fix this for xiangqi, shogi and fairy games
-      return Chess.default();
+    case 'shogi':
+      return Shogi.default();
+    case 'xiangqi':
+      return Xiangqi.default();
   }
 }
 
@@ -602,8 +649,9 @@ export function setupPosition(rules: Rules, setup: Setup): Result<Position, Posi
       return Crazyhouse.fromSetup(setup);
     case 'linesofaction':
       return LinesOfAction.fromSetup(setup);
-    default:
-      //TODO fix this for xiangqi, shogi and fairy games
-      return Chess.fromSetup(setup);
+    case 'shogi':
+      return Shogi.fromSetup(setup);
+    case 'xiangqi':
+      return Xiangqi.fromSetup(setup);
   }
 }


### PR DESCRIPTION
Fairysf wrapper placeholder classes to integrate shogi and xiangqi, to be expanded when these games are required within the analysis page. 